### PR TITLE
feat(memory): simplify pietta hierarchy and align remember/init behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,42 +14,48 @@ Pietta gives each agent its own local memory repo and organizes durable memory i
 - creates a dedicated memory repo per agent under `~/.pi/pietta/agents/<agent-id>/`
 - stores durable memory as normal files instead of an opaque database
 - separates memory into `project`, `agent`, and `session` scopes
-- keeps project summaries, decisions, scratchpads, timelines, and rule folders
+- keeps a simple top-level hierarchy of system, projects, sessions, rules, per-project timelines, and maintenance files
 - injects lightweight Pietta context before the agent starts
 - exposes slash commands and tools for remembering, grepping, updating, and deleting memory
 
 ## Current storage layout
 
-For an agent named `default`, Pietta creates:
+For an agent named `default`, Pietta now prefers a simpler top-level hierarchy:
 
 ```text
 ~/.pi/pietta/agents/default/
 ├── memory.git/
 └── memory/
     ├── README.md
-    ├── profile/
-    │   ├── preferences.md
-    │   ├── environment.md
-    │   └── habits.md
+    ├── system/
+    │   ├── README.md
+    │   └── <agent-chosen-files-and-subdirs>
     ├── projects/
     │   └── <project-slug>/
-    │       ├── SUMMARY.md
-    │       ├── decisions.md
-    │       ├── timeline.jsonl
-    │       ├── scratchpad.md
-    │       └── facts/
-    ├── agent/
+    │       ├── README.md
+    │       ├── system/
+    │       │   └── <agent-chosen-files-and-subdirs>
+    │       ├── rules/
+    │       └── timeline.jsonl
     ├── sessions/
     │   └── memory/
     ├── summaries/
     │   └── latest.md
     ├── inbox/
     │   └── candidates.jsonl
-    └── rules/
-        ├── project/
-        ├── agent/
-        └── generated/
+    ├── rules/
+    │   ├── agent/
+    │   └── generated/
+    └── archive/
 ```
+
+Notes:
+
+- Pietta does **not** prescribe fixed subfolders inside `system/`
+- Pietta does **not** prescribe fixed subfolders inside `projects/<slug>/`
+- the agent can organize both `system/` and project memory however it decides
+- each project also has a `projects/<slug>/system/` area for project-pinned memory
+- no generic `/init` command is introduced; `/pietta-init` remains canonical
 
 ## Project model
 
@@ -61,26 +67,38 @@ Example:
 - project slug: `pietta`
 - project memory dir: `projects/pietta/`
 
-Project-scoped durable memories are written into:
+Project-scoped durable memories default to the project root and supporting subpaths under:
 
 ```text
-projects/<project-slug>/facts/
+projects/<project-slug>/
+```
+
+Project-scoped rules, conventions, and stable preferences should generally live under:
+
+```text
+projects/<project-slug>/system/
+```
+
+Ordinary project facts can live directly under:
+
+```text
+projects/<project-slug>/
 ```
 
 This means Pietta is project-aware, but projects are not yet first-class objects with their own metadata model beyond the directory layout.
+
+By default, project remembers now prefer `projects/<slug>/system/` for high-priority project rules/conventions/preferences and `projects/<slug>/` for ordinary project facts, unless the agent explicitly chooses a subpath.
 
 ## Rules model
 
 Rules are plain markdown files stored in:
 
-- `rules/project/`
-- `rules/agent/`
-- `rules/generated/`
+- `projects/<slug>/rules/` for project rules
+- `rules/agent/` for agent rules
+- `rules/generated/` for generated rules
 
 Right now, rules are:
 
-- created as folders with README stubs during init
-- listed by the `/rules` command
 - searchable through Pietta grep
 - referenced in injected context by file path
 
@@ -102,41 +120,45 @@ Duplicate names get numeric suffixes like `_2`.
 
 ## What gets injected before agent start
 
-Pietta injects a hidden context block that currently includes:
+Pietta injects a hidden context block that now emphasizes hierarchy:
 
 - the current agent id
 - the memory root path
 - memory discipline guidance
+- the active hierarchy roots (`system/`, project, project system, session, rules, inbox)
 - the current project summary, if present
 - the latest summary, if present
+- pinned `system/` and project system memory snippets when available
 - a list of available rule file paths, if present
+- a lightweight tree view of pinned system memory
 
-It does **not** automatically inject all memory files or rule contents.
+It still does **not** automatically inject the full contents of every memory file.
 
 ## Search behavior
 
 Pietta grep is designed to work like ripgrep.
 
-Current grep scope is limited to the active project and non-project shared agent areas:
+Current grep scope is limited to the active project and shared agent areas for the current agent:
 
-- current `projectDir`
-- `profileDir`
-- `agentNotesDir`
+- current `projectDir` (including `projects/<slug>/rules/`)
+- pinned `system/` and `projects/<slug>/system/` memory
+- shared `rulesDir` (`rules/agent/` and `rules/generated/`)
 - `sessionMemoryDir`
-- `rulesDir`
 - `summariesDir`
 - `inboxDir`
-
-It deliberately does **not** grep other projects in the same agent repo.
 
 ## Slash commands
 
 Current command surface:
 
-- `/pietta-init` — initialize Pietta for the current or selected agent
+- `/pietta-init` — initialize or re-analyze Pietta for the current or selected agent
+  - ensures the Pietta layout exists for the selected agent
+  - sends a Letta-style user message so the agent can inspect the project and update memory through Pietta tools
 - `/agent` — switch the active Pietta agent
 - `/pietta-doctor` — audit and repair memory layout
-- `/remember` — store a durable memory item
+- `/remember` — promote a durable lesson, preference, rule, or fact into the right hierarchy
+  - sends a Letta-style user message so the agent can infer, rewrite, and store the right durable memory from context
+  - explicit scope and `path=subdir/file_name` are passed through as strong placement hints for the agent to follow
 - `/memory list`
 - `/memory recent`
 - `/memory show <id>`
@@ -148,8 +170,6 @@ Current command surface:
 - `/memory worktrees`
 - `/memory worktree-add <name>`
 - `/memory worktree-remove <name>`
-
-- `/rules` — list rule files
 - `/agents` — list, add, or switch agents
 
 ## Registered tools
@@ -230,18 +250,20 @@ Pietta is currently an early file-first implementation of the original plan in `
 
 Implemented now:
 
-- per-agent git-backed repo layout
+- Letta-inspired `system/` vs project hierarchy
 - real git commits for memory writes, updates, and deletes
 - automatic per-session worktrees for concurrent mutations
 - attached worktree visibility in `/pietta-doctor`
 - scoped durable memory writing
+- hierarchy-aware remember placement for pinned agent memory
 - meaningful memory filenames
 - memory grep
-- project summaries and rule directories
-- lightweight context injection
+- simple top-level hierarchy without prescribed subfolders inside `system/` or `projects/<slug>/`
+- lightweight context injection with pinned system snippets
 
 Not implemented yet:
 
+- richer multi-step interactive `/pietta-init` interviews beyond the current user-message-driven init flow
 - smart rule selection and just-in-time rule content injection
 - cross-project or cross-agent sync
 - semantic retrieval or embeddings

--- a/src/commands/parsing.ts
+++ b/src/commands/parsing.ts
@@ -9,6 +9,7 @@ import {
 	SCOPE_VALUES,
 	type AgentsArgs,
 	type MemoryArgs,
+	type RememberArgs,
 	type Scope,
 } from "../core/types.js"
 
@@ -116,16 +117,44 @@ export function parseAgentsArgs(args: string): AgentsArgs {
 	return { command, value: rest.join(" ") || undefined }
 }
 
-export function parseRememberArgs(args: string): {
-	scope: Scope
-	text: string
-} {
+export function parseRememberArgs(args: string): RememberArgs {
 	const trimmed = args.trim()
-	if (!trimmed) return { scope: "project", text: "" }
-	const [first, ...rest] = trimmed.split(/\s+/)
-	if ((SCOPE_VALUES as readonly string[]).includes(first))
-		return { scope: first as Scope, text: rest.join(" ") }
-	return { scope: "project", text: trimmed }
+	if (!trimmed)
+		return { scope: "project", scopeExplicit: false, path: undefined, text: "" }
+
+	const parts = trimmed.split(/\s+/).filter(Boolean)
+	let scope: Scope = "project"
+	let scopeExplicit = false
+	const textParts: string[] = []
+	let pathValue: string | undefined
+	for (const [index, part] of parts.entries()) {
+		if (!scopeExplicit) {
+			if (index === 0 && (SCOPE_VALUES as readonly string[]).includes(part)) {
+				scope = part as Scope
+				scopeExplicit = true
+				continue
+			}
+			if (part.startsWith("scope=")) {
+				const scopeValue = part.slice(6)
+				if ((SCOPE_VALUES as readonly string[]).includes(scopeValue)) {
+					scope = scopeValue as Scope
+					scopeExplicit = true
+					continue
+				}
+			}
+		}
+		if (!pathValue && part.startsWith("path=")) {
+			pathValue = part.slice(5) || undefined
+			continue
+		}
+		textParts.push(part)
+	}
+	return {
+		scope,
+		scopeExplicit,
+		path: pathValue,
+		text: textParts.join(" "),
+	}
 }
 
 export function parseMemoryArgs(args: string): MemoryArgs {

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -10,6 +10,10 @@ import {
 	renderSyncStatus,
 	setConflictResolutionStrategy,
 } from "../core/git.js"
+import {
+	buildPiettaInitCommandPrompt,
+	buildRememberCommandPrompt,
+} from "../core/intelligence.js"
 import { ensureAgentLayout, resolveReadPaths } from "../core/layout.js"
 import {
 	collectMemoryItemsFromPaths,
@@ -17,7 +21,6 @@ import {
 	findMemoryItemInPaths,
 	getMemoryHistoryFromPaths,
 	grepMemoryInPaths,
-	remember,
 	renderMemoryItem,
 	renderMemoryList,
 	renderMemoryOverview,
@@ -48,18 +51,23 @@ export function registerCommands(
 	setCurrentAgent: (agentId: string) => Promise<void>,
 ) {
 	pi.registerCommand("pietta-init", {
-		description: "Initialize Pietta memory for the current or selected agent",
+		description:
+			"Initialize or re-analyze Pietta memory for the current or selected agent",
 		getArgumentCompletions: (prefix) =>
 			toAutocompleteItems(getAgentIds(), prefix),
 		handler: async (args, ctx) => {
 			await syncState()
 			const agentId = sanitizeAgentId(args || getCurrentAgentId())
-			const result = await ensureAgentLayout(pi, ctx.cwd, agentId)
+			await ensureAgentLayout(pi, ctx.cwd, agentId)
 			await setCurrentAgent(agentId)
+			const prompt = buildPiettaInitCommandPrompt()
+			if (ctx.isIdle()) {
+				pi.sendUserMessage(prompt)
+				return
+			}
+			pi.sendUserMessage(prompt, { deliverAs: "followUp" })
 			ctx.ui.notify(
-				result.created.length > 0
-					? `Initialized Pietta for ${agentId} (${result.created.length} paths created)`
-					: `Pietta already initialized for ${agentId}`,
+				`Queued /pietta-init as a follow-up user message for ${agentId}`,
 				"info",
 			)
 		},
@@ -98,25 +106,18 @@ export function registerCommands(
 	})
 
 	pi.registerCommand("remember", {
-		description: "Store a durable Pietta memory entry",
+		description: "Send a Letta-style memory request to the agent",
 		getArgumentCompletions: getRememberCompletions,
 		handler: async (args, ctx) => {
 			await syncState()
 			const remembered = parseRememberArgs(args)
-			let text = remembered.text
-			if (!text)
-				text = (await ctx.ui.editor("Remember what?", ""))?.trim() || ""
-			if (!text) {
-				ctx.ui.notify("Nothing to remember", "warning")
+			const prompt = buildRememberCommandPrompt(remembered)
+			if (ctx.isIdle()) {
+				pi.sendUserMessage(prompt)
 				return
 			}
-			const filePath = await remember(pi, ctx, getCurrentAgentId(), {
-				text,
-				scope: remembered.scope,
-				kind: "fact",
-				confidence: 0.9,
-			})
-			ctx.ui.notify(`Remembered in ${filePath}`, "info")
+			pi.sendUserMessage(prompt, { deliverAs: "followUp" })
+			ctx.ui.notify("Queued /remember as a follow-up user message", "info")
 		},
 	})
 

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -2,8 +2,24 @@ import path from "node:path"
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
 import { truncateHead } from "@mariozechner/pi-coding-agent"
 import { ensureAgentLayout } from "./layout.js"
-import { collectMarkdownFiles, readFileIfPresent } from "./memory.js"
-
+import {
+	collectMarkdownFiles,
+	EMPTY_LATEST_SUMMARY,
+	getRuleRoots,
+	readFirstPresentFile,
+} from "./memory.js"
+function isScaffoldReadme(
+	paths: Awaited<ReturnType<typeof ensureAgentLayout>>["paths"],
+	filePath: string,
+): boolean {
+	return (
+		filePath === path.join(paths.systemDir, "README.md") ||
+		filePath === path.join(paths.projectSystemDir, "README.md") ||
+		filePath === path.join(paths.projectRulesDir, "README.md") ||
+		filePath === path.join(paths.agentRulesDir, "README.md") ||
+		filePath === path.join(paths.generatedRulesDir, "README.md")
+	)
+}
 export async function buildInjectedContext(
 	pi: ExtensionAPI,
 	cwd: string,
@@ -11,12 +27,49 @@ export async function buildInjectedContext(
 ): Promise<string | null> {
 	const { paths } = await ensureAgentLayout(pi, cwd, agentId)
 	const projectSummary = (
-		await readFileIfPresent(paths.projectSummaryFile)
+		await readFirstPresentFile([paths.projectSummaryFile])
 	)?.trim()
 	const latestSummary = (
-		await readFileIfPresent(paths.latestSummaryFile)
+		await readFirstPresentFile([paths.latestSummaryFile])
 	)?.trim()
-	const ruleFiles = await collectMarkdownFiles(paths.rulesDir)
+	const systemFiles = await collectMarkdownFiles(paths.systemDir)
+	const projectSystemFiles = await collectMarkdownFiles(paths.projectSystemDir)
+	const ruleRoots = getRuleRoots(paths)
+	const rulePaths = (
+		await Promise.all(
+			ruleRoots.map(async (root) => {
+				const files = await collectMarkdownFiles(root)
+				return files
+					.map((file) => path.join(root, file))
+					.filter((filePath) => !isScaffoldReadme(paths, filePath))
+			}),
+		)
+	).flat()
+	const pinnedEntries = [
+		...systemFiles.map((file) => ({
+			label: `system/${file}`,
+			filePath: path.join(paths.systemDir, file),
+		})),
+		...projectSystemFiles.map((file) => ({
+			label: `projects/<slug>/system/${file}`,
+			filePath: path.join(paths.projectSystemDir, file),
+		})),
+	]
+	const pinnedSystemSnippets = (
+		await Promise.all(
+			pinnedEntries
+				.filter(({ filePath }) => !isScaffoldReadme(paths, filePath))
+				.slice(0, 12)
+				.map(async ({ label, filePath }) => {
+					const content = (await readFirstPresentFile([filePath]))?.trim()
+					if (!content) return null
+					return `### ${label}\n${content}`
+				}),
+		)
+	).filter(Boolean) as string[]
+	const memoryTreeLines = pinnedEntries
+		.filter(({ filePath }) => !isScaffoldReadme(paths, filePath))
+		.map(({ label }) => `- ${label}`)
 	const blocks = [
 		"# Pietta Context",
 		`- agent: ${agentId}`,
@@ -25,19 +78,31 @@ export async function buildInjectedContext(
 		"## Memory Discipline",
 		"- Treat explicit user preferences as durable memory.",
 		"- If the user says something is their preference, default, usual workflow, or recurring constraint, store it in Pietta memory.",
+		"- `system/` is pinned high-priority memory, but Pietta does not prescribe internal subfolders there.",
+		"- `projects/<slug>/` is project-scoped memory, but Pietta does not prescribe internal subfolders there either.",
 		"- Do this proactively without asking for confirmation unless the user says not to remember it.",
 		"- Never store secrets, credentials, or clearly temporary details.",
+		"",
+		"## Hierarchy",
+		`- pinned system root: ${paths.systemDir}`,
+		`- project root: ${paths.projectDir}`,
+		`- project system root: ${paths.projectSystemDir}`,
+		`- session root: ${paths.sessionMemoryDir}`,
+		`- shared rules root: ${paths.rulesDir}`,
+		`- project rules root: ${paths.projectRulesDir}`,
+		`- inbox root: ${paths.inboxDir}`,
 	]
 	if (projectSummary) blocks.push(`## Project Summary\n${projectSummary}`)
-	if (
-		latestSummary &&
-		latestSummary !== "# Latest Summary\n\nNo generated summary yet."
-	)
+	if (latestSummary && latestSummary !== EMPTY_LATEST_SUMMARY)
 		blocks.push(`## Latest Summary\n${latestSummary}`)
-	if (ruleFiles.length > 0)
+	if (pinnedSystemSnippets.length > 0)
+		blocks.push(`## Pinned System Memory\n${pinnedSystemSnippets.join("\n\n")}`)
+	if (rulePaths.length > 0)
 		blocks.push(
-			`## Available Rules\n${ruleFiles.map((file) => `- ${path.join(paths.rulesDir, file)}`).join("\n")}`,
+			`## Available Rules\n${rulePaths.map((file) => `- ${file}`).join("\n")}`,
 		)
+	if (memoryTreeLines.length > 0)
+		blocks.push(`## Memory Tree\n${memoryTreeLines.join("\n")}`)
 	return (
 		truncateHead(blocks.join("\n\n"), {
 			maxBytes: 12_000,

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -557,11 +557,16 @@ export async function commitWorktreeChanges(
 	}
 	if (!(await hasGitChanges(pi, workTree))) return
 	await ensureGitIdentity(pi, workTree)
-	await gitOrThrow(
-		pi,
-		["commit", "-m", message],
-		`Failed to commit memory changes in ${workTree}`,
-		{ cwd: workTree },
+	const result = await git(pi, ["commit", "-m", message], { cwd: workTree })
+	if (result.code === 0) return
+	const output = `${result.stderr}\n${result.stdout}`
+	if (/nothing to commit|working tree clean/i.test(output)) return
+	throw new Error(
+		getGitFailureMessage(
+			`Failed to commit memory changes in ${workTree}`,
+			["commit", "-m", message],
+			result,
+		),
 	)
 }
 

--- a/src/core/intelligence.ts
+++ b/src/core/intelligence.ts
@@ -1,0 +1,271 @@
+import { complete } from "@mariozechner/pi-ai"
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent"
+import type { RememberArgs, Scope } from "./types.js"
+
+type ContentBlock = {
+	type?: string
+	text?: string
+	name?: string
+	arguments?: Record<string, unknown>
+}
+
+type SessionEntryLike = {
+	type: string
+	message?: {
+		role?: string
+		content?: unknown
+	}
+}
+
+type RememberInference = {
+	text: string
+	scope: Scope
+	kind: string
+	path?: string
+}
+
+const LETTA_STYLE_REMEMBER_PROMPT = `# Memory Request
+
+The user has invoked the /remember command, which indicates they want you to commit something to memory.
+
+## What This Means
+
+The user wants you to use your memory tools to remember information from the conversation. This could be:
+
+- A correction
+- A preference
+- A fact
+- A rule
+
+## Your Task
+1. Identify what to remember from the recent conversation context. If the user provided text after /remember, that is a strong hint, but you should still rewrite it into concise durable memory.
+2. Determine the right memory block and placement. Choose scope, kind, and an optional nested slash-separated path.
+3. Split distinct topics across multiple memory files when appropriate instead of stuffing unrelated things into one note.
+4. Keep each memory focused and short — ideally a paragraph or two.
+5. Use Pietta memory tools to store it.
+6. Briefly confirm what you remembered and where you stored it.
+- NEVER write directly to memory files yourself in this flow; use Pietta memory tools instead.
+- Be concise and distill the information to its essence
+- Avoid duplicates and overly transient details
+- Match the intent of a durable memory edit, not a raw transcript dump
+- Prefer multiple small focused memories over one large catch-all memory
+- If the request is unclear, ask for clarification instead of inventing details
+`
+
+export function buildRememberCommandPrompt(args?: RememberArgs): string {
+	const normalizedText = args?.text?.trim()
+	const placementHints = [
+		args?.scopeExplicit
+			? `The user explicitly selected scope: ${args.scope}`
+			: "",
+		args?.path ? `The user explicitly selected path: ${args.path}` : "",
+	]
+		.filter(Boolean)
+		.join("\n")
+	return [
+		LETTA_STYLE_REMEMBER_PROMPT,
+		"The user explicitly invoked /remember. Use Pietta memory tools to store the durable memory in the right hierarchy.",
+		placementHints,
+		normalizedText
+			? `The user provided this hint after /remember: ${normalizedText}`
+			: "The user did not provide text after /remember. Infer the durable memory from recent conversation context.",
+		args?.scopeExplicit
+			? "Respect the user's explicit scope unless you truly need clarification."
+			: "",
+		args?.path
+			? "Respect the user's explicit slash-separated path unless you truly need clarification. Apply only normal filename sanitization if you store memory there."
+			: "",
+		"Rewrite the memory into concise durable form instead of copying raw user text verbatim when a cleaner memory note would be better.",
+		"After updating memory, briefly confirm what you remembered and where you stored it.",
+	]
+		.filter(Boolean)
+		.join("\n\n")
+}
+
+const LETTA_STYLE_INIT_PROMPT = `# Memory Initialization Request
+The user has invoked /pietta-init. This means they want a deeper, interactive memory initialization or re-analysis pass for the current project.
+
+A shallow Pietta bootstrap may already have created starter files. Treat this turn like Letta Code's manual /init flow: inspect what exists, refine it, fill obvious gaps, and organize memory into a useful filesystem shape.
+## Your Task
+1. Inspect the current project and existing Pietta memory.
+2. Refine existing memory in place when it already covers a topic instead of creating duplicates.
+3. Create or update a small useful project memory skeleton where needed.
+4. Ask follow-up questions only if important memory gaps are obvious and you genuinely need clarification.
+5. Split distinct topics across multiple memories when appropriate instead of stuffing unrelated things into one file.
+6. Keep each memory focused and short — ideally a paragraph or two.
+7. Use \`projects/<slug>/system/\` for project-pinned guidance and \`projects/<slug>/\` for ordinary project memory unless a different nested path is clearly better.
+8. Briefly confirm what you initialized or updated.
+- NEVER write directly to memory files yourself in this flow; use Pietta memory tools instead.
+- Prefer a small, useful skeleton over a large dump
+- Avoid duplicates and unnecessary rewrites
+- Refine memory if it has drifted instead of redoing everything blindly
+- Leave room for the memory tree to grow over time
+`
+export function buildPiettaInitCommandPrompt(): string {
+	return [
+		LETTA_STYLE_INIT_PROMPT,
+		"The user explicitly invoked /pietta-init. Perform the deeper interactive init pass now.",
+		"If the current memory already has the right structure, refine and extend it instead of recreating it.",
+		"After updating memory, briefly confirm what you initialized and where you stored it.",
+	].join("\n\n")
+}
+
+function extractTextParts(content: unknown): string[] {
+	if (typeof content === "string") return [content]
+	if (!Array.isArray(content)) return []
+
+	const textParts: string[] = []
+	for (const part of content) {
+		if (!part || typeof part !== "object") continue
+		const block = part as ContentBlock
+		if (block.type === "text" && typeof block.text === "string") {
+			textParts.push(block.text)
+		}
+	}
+	return textParts
+}
+
+function extractToolCallLines(content: unknown): string[] {
+	if (!Array.isArray(content)) return []
+
+	const toolCalls: string[] = []
+	for (const part of content) {
+		if (!part || typeof part !== "object") continue
+		const block = part as ContentBlock
+		if (block.type !== "toolCall" || typeof block.name !== "string") continue
+		toolCalls.push(
+			`Tool ${block.name} was called with args ${JSON.stringify(block.arguments ?? {})}`,
+		)
+	}
+	return toolCalls
+}
+
+export function buildConversationText(
+	entries: SessionEntryLike[],
+	maxMessages: number = 12,
+): string {
+	const relevantEntries = entries.filter(
+		(entry) =>
+			entry.type === "message" &&
+			(entry.message?.role === "user" || entry.message?.role === "assistant"),
+	)
+	const sections: string[] = []
+
+	for (const entry of relevantEntries.slice(-maxMessages)) {
+		const role = entry.message?.role
+		if (!role) continue
+		const isUser = role === "user"
+		const isAssistant = role === "assistant"
+		const entryLines: string[] = []
+		const textParts = extractTextParts(entry.message?.content)
+		if (textParts.length > 0) {
+			const messageText = textParts.join("\n").trim()
+			if (messageText)
+				entryLines.push(`${isUser ? "User" : "Assistant"}: ${messageText}`)
+		}
+		if (isAssistant)
+			entryLines.push(...extractToolCallLines(entry.message?.content))
+		if (entryLines.length > 0) sections.push(entryLines.join("\n"))
+	}
+
+	return sections.join("\n\n")
+}
+
+function extractJsonObject(text: string): string | null {
+	const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i)
+	if (fenced?.[1]) return fenced[1].trim()
+	const start = text.indexOf("{")
+	const end = text.lastIndexOf("}")
+	if (start === -1 || end === -1 || end <= start) return null
+	return text.slice(start, end + 1)
+}
+
+async function completeJson<T>(
+	ctx: ExtensionContext,
+	prompt: string,
+): Promise<T | null> {
+	if (!ctx.model) return null
+	const apiKey = await ctx.modelRegistry.getApiKey(ctx.model)
+	if (!apiKey) return null
+
+	const response = await complete(
+		ctx.model,
+		{
+			messages: [
+				{
+					role: "user",
+					content: [{ type: "text", text: prompt }],
+					timestamp: Date.now(),
+				},
+			],
+		},
+		{ apiKey, reasoningEffort: "medium" },
+	)
+	const text = response.content
+		.filter(
+			(part): part is { type: "text"; text: string } => part.type === "text",
+		)
+		.map((part) => part.text)
+		.join("\n")
+	const jsonText = extractJsonObject(text)
+	if (!jsonText) return null
+	try {
+		return JSON.parse(jsonText) as T
+	} catch {
+		return null
+	}
+}
+
+function normalizeInferredScope(value: unknown, fallback: Scope): Scope {
+	return value === "project" || value === "agent" || value === "session"
+		? value
+		: fallback
+}
+
+function normalizeOptionalPath(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined
+}
+
+export async function inferRememberInputFromContext(
+	ctx: ExtensionContext,
+	defaults?: Partial<RememberInference> & {
+		scopeExplicit?: boolean
+		commandText?: string
+	},
+): Promise<RememberInference | null> {
+	const branch = ctx.sessionManager.getBranch() as SessionEntryLike[]
+	const conversationText = buildConversationText(branch)
+	if (!conversationText.trim() && !defaults?.commandText?.trim()) return null
+	const inferred = await completeJson<RememberInference>(
+		ctx,
+		[
+			LETTA_STYLE_REMEMBER_PROMPT,
+			defaults?.scopeExplicit && defaults.scope
+				? `Use scope ${defaults.scope} exactly.`
+				: "Infer the best scope from the conversation.",
+			defaults?.path
+				? `Prefer this path if it still fits: ${defaults.path}`
+				: "",
+			defaults?.kind ? `Prefer kind ${defaults.kind}.` : "",
+			defaults?.commandText?.trim()
+				? `User text after /remember: ${defaults.commandText.trim()}`
+				: "User text after /remember: <none>",
+			"",
+			"<conversation>",
+			conversationText,
+			"</conversation>",
+		]
+			.filter(Boolean)
+			.join("\n"),
+	)
+	if (!inferred?.text?.trim()) return null
+	return {
+		text: inferred.text.trim(),
+		scope: normalizeInferredScope(inferred.scope, defaults?.scope ?? "project"),
+		kind:
+			typeof inferred.kind === "string" && inferred.kind.trim()
+				? inferred.kind.trim()
+				: defaults?.kind?.trim() || "fact",
+		path: normalizeOptionalPath(inferred.path ?? defaults?.path),
+	}
+}

--- a/src/core/layout.ts
+++ b/src/core/layout.ts
@@ -29,7 +29,6 @@ export async function ensureDir(dir: string, created: string[]): Promise<void> {
 	await mkdir(dir, { recursive: true })
 	created.push(dir)
 }
-
 export async function ensureFile(
 	filePath: string,
 	content: string,
@@ -40,7 +39,6 @@ export async function ensureFile(
 	await writeFile(filePath, content, "utf8")
 	created.push(filePath)
 }
-
 export function getDefaultFiles(
 	cwd: string,
 	agentId: string,
@@ -50,23 +48,41 @@ export function getDefaultFiles(
 	const now = new Date().toISOString()
 	return {
 		[path.join(paths.workTree, "README.md")]:
-			`# Pietta Memory\n\nThis git-backed worktree stores durable memory for agent \`${agentId}\`.\n`,
-		[path.join(paths.profileDir, "preferences.md")]:
-			`# Preferences\n\nStable project and agent preferences.\n`,
-		[path.join(paths.profileDir, "environment.md")]:
-			`# Environment\n\nEnvironment constraints.\n`,
-		[path.join(paths.profileDir, "habits.md")]:
-			`# Habits\n\nRepeated workflow habits.\n`,
-		[paths.projectSummaryFile]: `# ${projectSlug} Summary\n\n- Initialized: ${now}\n- Agent: ${agentId}\n`,
-		[paths.projectDecisionsFile]: `# Decisions\n\n`,
+			`# Pietta Memory\n\nThis git-backed worktree stores durable memory for agent \`${agentId}\`.\n\n## Hierarchy\n\n- \`system/\` is pinned high-priority memory, but Pietta does not prescribe fixed subfolders inside it\n- \`projects/<slug>/\` is project-scoped memory, and Pietta does not prescribe fixed subfolders there either\n- \`sessions/\`, \`rules/\`, \`inbox/\`, and \`archive/\` hold supporting memory and maintenance data\n`,
+		[path.join(paths.systemDir, "README.md")]:
+			`# System Memory\n\nPinned high-priority memory. Organize this however the agent decides.\n`,
+		[path.join(paths.projectSystemDir, "README.md")]:
+			`# Project System Memory\n\nPinned high-priority memory for this project. Organize this however the agent decides.\n`,
+		[paths.projectSummaryFile]: `# ${projectSlug}\n\nProject-scoped memory. Organize this however the agent decides.\n\n- Initialized: ${now}\n- Agent: ${agentId}\n`,
 		[paths.timelineFile]: "",
-		[paths.scratchpadFile]: `# Scratchpad\n\n`,
 		[paths.latestSummaryFile]: `# Latest Summary\n\nNo generated summary yet.\n`,
 		[paths.candidatesFile]: "",
 		[path.join(paths.projectRulesDir, "README.md")]: "# Project Rules\n\n",
 		[path.join(paths.agentRulesDir, "README.md")]: "# Agent Rules\n\n",
 		[path.join(paths.generatedRulesDir, "README.md")]: "# Generated Rules\n\n",
 	}
+}
+
+export function getManagedDirectories(paths: MemoryPaths): string[] {
+	return [
+		paths.root,
+		paths.agentsDir,
+		paths.agentDir,
+		paths.worktreesDir,
+		paths.systemDir,
+		paths.projectsDir,
+		paths.projectSystemDir,
+		paths.projectDir,
+		paths.sessionsDir,
+		paths.sessionMemoryDir,
+		paths.summariesDir,
+		paths.inboxDir,
+		paths.archiveDir,
+		paths.rulesDir,
+		paths.projectRulesDir,
+		paths.agentRulesDir,
+		paths.generatedRulesDir,
+	]
 }
 
 export async function ensureAgentLayout(
@@ -85,7 +101,6 @@ export async function ensureAgentLayout(
 	]) {
 		await ensureDir(dir, created)
 	}
-
 	if (!(await exists(basePaths.bareRepo))) {
 		await gitOrThrow(
 			pi,
@@ -94,7 +109,6 @@ export async function ensureAgentLayout(
 		)
 		created.push(basePaths.bareRepo)
 	}
-
 	if (!(await exists(basePaths.workTree))) {
 		await gitOrThrow(
 			pi,
@@ -106,21 +120,7 @@ export async function ensureAgentLayout(
 	}
 	await ensureGitIdentity(pi, basePaths.workTree)
 	await syncCanonicalBranchFromBare(pi, basePaths)
-
-	for (const dir of [
-		basePaths.profileDir,
-		basePaths.projectDir,
-		basePaths.projectFactsDir,
-		basePaths.sessionsDir,
-		basePaths.sessionMemoryDir,
-		basePaths.summariesDir,
-		basePaths.inboxDir,
-		basePaths.rulesDir,
-		basePaths.projectRulesDir,
-		basePaths.agentRulesDir,
-		basePaths.generatedRulesDir,
-		basePaths.agentNotesDir,
-	]) {
+	for (const dir of getManagedDirectories(basePaths)) {
 		await ensureDir(dir, created)
 	}
 	for (const [filePath, content] of Object.entries(
@@ -140,7 +140,6 @@ export async function ensureAgentLayout(
 		)
 		await pushCanonicalBranchToBare(pi, basePaths)
 	}
-
 	const paths = await ensureMemoryWorktree(
 		pi,
 		cwd,
@@ -150,7 +149,6 @@ export async function ensureAgentLayout(
 	)
 	return { paths, created }
 }
-
 export async function ensureWorktreeLayout(
 	cwd: string,
 	agentId: string,
@@ -159,20 +157,7 @@ export async function ensureWorktreeLayout(
 	if (!(await hasGitWorkTreeFile(paths.workTree))) {
 		throw new Error(`Refusing to populate non-git worktree: ${paths.workTree}`)
 	}
-	for (const dir of [
-		paths.profileDir,
-		paths.projectDir,
-		paths.projectFactsDir,
-		paths.sessionsDir,
-		paths.sessionMemoryDir,
-		paths.summariesDir,
-		paths.inboxDir,
-		paths.rulesDir,
-		paths.projectRulesDir,
-		paths.agentRulesDir,
-		paths.generatedRulesDir,
-		paths.agentNotesDir,
-	]) {
+	for (const dir of getManagedDirectories(paths)) {
 		await mkdir(dir, { recursive: true })
 	}
 	for (const [filePath, content] of Object.entries(
@@ -183,7 +168,6 @@ export async function ensureWorktreeLayout(
 		await writeFile(filePath, content, "utf8")
 	}
 }
-
 export async function resolveMutationPaths(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,
@@ -198,7 +182,6 @@ export async function resolveMutationPaths(
 	await ensureWorktreeLayout(ctx.cwd, agentId, paths)
 	return { paths, worktreeKey, source }
 }
-
 export async function resolveReadPaths(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,

--- a/src/core/memory.ts
+++ b/src/core/memory.ts
@@ -4,6 +4,7 @@ import {
 	readFile,
 	stat,
 	unlink,
+	mkdir,
 	writeFile,
 } from "node:fs/promises"
 import { existsSync, readFileSync, readdirSync } from "node:fs"
@@ -37,18 +38,94 @@ import {
 } from "./paths.js"
 import type { MemoryItem, MemoryPaths, RememberInput, Scope } from "./types.js"
 
+export const EMPTY_LATEST_SUMMARY =
+	"# Latest Summary\n\nNo generated summary yet."
+
+function uniquePaths(pathsList: string[]): string[] {
+	return [...new Set(pathsList)]
+}
+
+const mutationQueues = new Map<string, Promise<void>>()
+
+async function withAgentMutationLock<T>(
+	agentId: string,
+	operation: () => Promise<T>,
+): Promise<T> {
+	const previous = mutationQueues.get(agentId) ?? Promise.resolve()
+	let release!: () => void
+	const current = new Promise<void>((resolve) => {
+		release = resolve
+	})
+	const queued = previous.catch(() => undefined).then(() => current)
+	mutationQueues.set(agentId, queued)
+	await previous.catch(() => undefined)
+	try {
+		return await operation()
+	} finally {
+		release()
+		if (mutationQueues.get(agentId) === queued) mutationQueues.delete(agentId)
+	}
+}
+
+export function getRuleRoots(paths: MemoryPaths): string[] {
+	return uniquePaths([paths.projectRulesDir, paths.rulesDir])
+}
+
+export function getPinnedSystemRoots(paths: MemoryPaths): string[] {
+	return uniquePaths([paths.systemDir, paths.projectSystemDir])
+}
 export function getMemoryRoots(
 	paths: MemoryPaths,
 ): Array<{ scope: Scope; dir: string }> {
-	return [
-		{ scope: "project", dir: paths.projectFactsDir },
-		{ scope: "agent", dir: paths.agentNotesDir },
+	const roots: Array<{ scope: Scope; dir: string }> = [
+		{ scope: "project", dir: paths.projectDir },
+		{ scope: "agent", dir: paths.systemDir },
 		{ scope: "session", dir: paths.sessionMemoryDir },
 	]
+	return roots
+}
+function isUnderDir(filePath: string, dir: string): boolean {
+	const relativePath = path.relative(dir, filePath)
+	return (
+		relativePath !== "" &&
+		!relativePath.startsWith("..") &&
+		!path.isAbsolute(relativePath)
+	)
 }
 
-export function getMemoryItemId(scope: Scope, filePath: string): string {
-	return `${scope}/${path.basename(filePath, ".md")}`
+function isScaffoldMemoryFile(paths: MemoryPaths, filePath: string): boolean {
+	return (
+		filePath === path.join(paths.systemDir, "README.md") ||
+		filePath === path.join(paths.projectSystemDir, "README.md") ||
+		filePath === paths.projectSummaryFile ||
+		filePath === path.join(paths.projectRulesDir, "README.md") ||
+		filePath === path.join(paths.agentRulesDir, "README.md") ||
+		filePath === path.join(paths.generatedRulesDir, "README.md")
+	)
+}
+export function isListedMemoryFile(
+	paths: MemoryPaths,
+	filePath: string,
+): boolean {
+	if (filePath === paths.projectSummaryFile) return false
+	if (!filePath.endsWith(".md")) return false
+	if (isScaffoldMemoryFile(paths, filePath)) return false
+	if (isUnderDir(filePath, paths.projectSystemDir)) return false
+	if (isUnderDir(filePath, paths.projectRulesDir)) return false
+	if (isUnderDir(filePath, paths.agentRulesDir)) return false
+	if (isUnderDir(filePath, paths.generatedRulesDir)) return false
+	return true
+}
+
+export function getMemoryItemId(
+	scope: Scope,
+	filePath: string,
+	rootDir?: string,
+): string {
+	const relativePath = rootDir
+		? path.relative(rootDir, filePath).replace(/\\/g, "/")
+		: path.basename(filePath)
+	return `${scope}/${relativePath.replace(/\.md$/i, "")}`
 }
 
 export function frontmatter(
@@ -96,17 +173,65 @@ export function parseFrontmatterBlock(content: string): {
 	return { data, body }
 }
 
-export function getRememberDir(paths: MemoryPaths, scope: Scope): string {
-	switch (scope) {
-		case "project":
-			return paths.projectFactsDir
-		case "agent":
-			return paths.agentNotesDir
-		case "session":
-			return paths.sessionMemoryDir
-	}
+export function getRememberDir(
+	paths: MemoryPaths,
+	scope: Scope,
+	kind: string,
+	text: string,
+): string {
+	if (scope === "session") return paths.sessionMemoryDir
+	if (scope === "agent") return paths.systemDir
+	if (scope !== "project") return paths.projectDir
+
+	const signal = `${kind} ${text}`.toLowerCase()
+	if (
+		/(rule|policy|constraint|preference|workflow|convention|guideline|standard|always|never|should|must)/.test(
+			signal,
+		)
+	)
+		return paths.projectSystemDir
+	return paths.projectDir
 }
 
+export function sanitizeMemoryPathSegment(value: string): string {
+	return slugifyMemoryName(value.replace(/\.md$/i, "")).replace(/^_+|_+$/g, "")
+}
+
+export function sanitizeRelativeMemoryPath(value: string): string | null {
+	const parts = value
+		.split(/[\\/]+/)
+		.map((part) => sanitizeMemoryPathSegment(part.trim()))
+		.filter(Boolean)
+	if (parts.length === 0) return null
+	return parts.join("/")
+}
+
+export async function resolveRememberTarget(
+	baseDir: string,
+	preferredStem: string,
+	explicitPath?: string,
+): Promise<{ relativePath: string; filePath: string }> {
+	const sanitizedPath = explicitPath
+		? sanitizeRelativeMemoryPath(explicitPath)
+		: null
+	if (!sanitizedPath) {
+		const stem = await getUniqueMemoryStem(baseDir, preferredStem)
+		return {
+			relativePath: stem,
+			filePath: path.join(baseDir, `${stem}.md`),
+		}
+	}
+
+	const parts = sanitizedPath.split("/")
+	const leaf = parts.pop() || preferredStem
+	const nestedDir = path.join(baseDir, ...parts)
+	const stem = await getUniqueMemoryStem(nestedDir, leaf || preferredStem)
+	const relativePath = [...parts, stem].filter(Boolean).join("/")
+	return {
+		relativePath,
+		filePath: path.join(baseDir, `${relativePath}.md`),
+	}
+}
 export function getMemoryTitle(text: string, kind: string): string {
 	const firstLine = text
 		.split("\n")
@@ -122,7 +247,6 @@ export function getMemoryTitle(text: string, kind: string): string {
 	const words = stem.split("_").filter(Boolean).slice(0, 8)
 	return words.join("_") || `${slugifyMemoryName(kind || "memory")}_entry`
 }
-
 export async function getUniqueMemoryStem(
 	dir: string,
 	preferredStem: string,
@@ -159,6 +283,7 @@ export async function collectMarkdownFiles(
 export async function getRecentFiles(
 	dir: string,
 	limit: number,
+	includeFile?: (filePath: string) => boolean,
 ): Promise<Array<{ file: string; mtimeMs: number }>> {
 	if (!(await exists(dir))) return []
 	const results: Array<{ file: string; mtimeMs: number }> = []
@@ -167,10 +292,11 @@ export async function getRecentFiles(
 		if (entry.name === ".git") continue
 		const fullPath = path.join(dir, entry.name)
 		if (entry.isDirectory()) {
-			results.push(...(await getRecentFiles(fullPath, limit)))
+			results.push(...(await getRecentFiles(fullPath, limit, includeFile)))
 			continue
 		}
 		if (!entry.isFile()) continue
+		if (includeFile && !includeFile(fullPath)) continue
 		const info = await stat(fullPath)
 		results.push({ file: fullPath, mtimeMs: info.mtimeMs })
 	}
@@ -192,12 +318,12 @@ export function getMemoryItemIdsSync(cwd: string, agentId: string): string[] {
 					stack.push(fullPath)
 					continue
 				}
-				if (!entry.isFile() || !entry.name.endsWith(".md")) continue
+				if (!entry.isFile() || !isListedMemoryFile(paths, fullPath)) continue
 				const parsed = parseFrontmatterBlock(readFileSync(fullPath, "utf8"))
 				ids.add(
 					typeof parsed.data.id === "string"
 						? parsed.data.id
-						: getMemoryItemId(scope, fullPath),
+						: getMemoryItemId(scope, fullPath, dir),
 				)
 			}
 		}
@@ -227,20 +353,22 @@ export async function collectMemoryItemsFromPaths(
 	const files = (
 		await Promise.all(
 			getMemoryRoots(paths).map(async ({ scope, dir }) => {
-				const recentFiles = await getRecentFiles(dir, 500)
-				return recentFiles.map((file) => ({ ...file, scope }))
+				const recentFiles = await getRecentFiles(dir, 500, (filePath) =>
+					isListedMemoryFile(paths, filePath),
+				)
+				return recentFiles.map((file) => ({ ...file, scope, rootDir: dir }))
 			}),
 		)
 	).flat()
 	const items: MemoryItem[] = []
 	for (const file of files) {
-		if (!file.file.endsWith(".md")) continue
+		if (!isListedMemoryFile(paths, file.file)) continue
 		const parsed = parseFrontmatterBlock(await readFile(file.file, "utf8"))
 		items.push({
 			id:
 				typeof parsed.data.id === "string"
 					? parsed.data.id
-					: getMemoryItemId(file.scope, file.file),
+					: getMemoryItemId(file.scope, file.file, file.rootDir),
 			filePath: file.file,
 			scope: file.scope,
 			kind: typeof parsed.data.kind === "string" ? parsed.data.kind : "fact",
@@ -305,68 +433,70 @@ export async function remember(
 	agentId: string,
 	input: RememberInput,
 ): Promise<string> {
-	const { paths, worktreeKey, source } = await resolveMutationPaths(
-		pi,
-		ctx,
-		agentId,
-	)
-	const now = new Date().toISOString()
-	const provenanceSource = input.source?.trim() || source
-	const dir = getRememberDir(paths, input.scope)
-	const stem = await getUniqueMemoryStem(
-		dir,
-		getMemoryTitle(input.text, input.kind),
-	)
-	const id = `${input.scope}/${stem}`
-	const filePath = path.join(dir, `${stem}.md`)
-	const content = `${frontmatter({
-		id,
-		scope: input.scope,
-		project: getProjectSlug(ctx.cwd),
-		agent: agentId,
-		kind: input.kind,
-		confidence: input.confidence.toFixed(2),
-		sources: [provenanceSource],
-		created_at: now,
-		updated_at: now,
-	})}\n\n${input.text.trim()}\n`
-	await writeFile(filePath, content, "utf8")
-	await appendTimeline(paths, {
-		id,
-		timestamp: now,
-		action: "remember",
-		agent: agentId,
-		scope: input.scope,
-		kind: input.kind,
-		file: filePath,
-		source: provenanceSource,
+	return withAgentMutationLock(agentId, async () => {
+		const { paths, worktreeKey, source } = await resolveMutationPaths(
+			pi,
+			ctx,
+			agentId,
+		)
+		const now = new Date().toISOString()
+		const provenanceSource = input.source?.trim() || source
+		const dir = getRememberDir(paths, input.scope, input.kind, input.text)
+		const preferredStem = getMemoryTitle(input.text, input.kind)
+		const target = await resolveRememberTarget(dir, preferredStem, input.path)
+		const id = `${input.scope}/${target.relativePath}`
+		const filePath = target.filePath
+		const content = `${frontmatter({
+			id,
+			scope: input.scope,
+			project: getProjectSlug(ctx.cwd),
+			agent: agentId,
+			kind: input.kind,
+			confidence: input.confidence.toFixed(2),
+			sources: [provenanceSource],
+			created_at: now,
+			updated_at: now,
+		})}
+${input.text.trim()}
+`
+		await mkdir(path.dirname(filePath), { recursive: true })
+		await writeFile(filePath, content, "utf8")
+		await appendTimeline(paths, {
+			id,
+			timestamp: now,
+			action: "remember",
+			agent: agentId,
+			scope: input.scope,
+			kind: input.kind,
+			file: filePath,
+			source: provenanceSource,
+		})
+		await appendCandidates(paths, {
+			id,
+			timestamp: now,
+			action: "remember",
+			agent: agentId,
+			scope: input.scope,
+			kind: input.kind,
+			confidence: input.confidence,
+			text: input.text.trim(),
+			file: filePath,
+			source: provenanceSource,
+		})
+		await commitWorktreeChanges(
+			pi,
+			paths.workTree,
+			`feat(memory): remember ${id}`,
+			toWorktreeRelativePaths(paths, [
+				filePath,
+				paths.timelineFile,
+				paths.candidatesFile,
+			]),
+		)
+		await fastForwardCanonicalBranch(pi, paths, worktreeKey)
+		await pushCanonicalBranchToBare(pi, paths)
+		return filePath
 	})
-	await appendCandidates(paths, {
-		id,
-		timestamp: now,
-		action: "remember",
-		agent: agentId,
-		scope: input.scope,
-		kind: input.kind,
-		confidence: input.confidence,
-		text: input.text.trim(),
-		file: filePath,
-		source: provenanceSource,
-	})
-	await commitWorktreeChanges(
-		pi,
-		paths.workTree,
-		`feat(memory): remember ${id}`,
-		toWorktreeRelativePaths(paths, [
-			filePath,
-			paths.timelineFile,
-			paths.candidatesFile,
-		]),
-	)
-	await fastForwardCanonicalBranch(pi, paths, worktreeKey)
-	await pushCanonicalBranchToBare(pi, paths)
-
-	return filePath
 }
 
 export async function updateMemoryItem(
@@ -377,75 +507,80 @@ export async function updateMemoryItem(
 	text: string,
 	options?: { mode?: "replace" | "append"; source?: string },
 ): Promise<MemoryItem> {
-	const { paths, worktreeKey, source } = await resolveMutationPaths(
-		pi,
-		ctx,
-		agentId,
-	)
-	const item = await findMemoryItemInPaths(paths, selector)
-	if (!item) throw new Error(`Could not find memory item: ${selector}`)
-	const now = new Date().toISOString()
-	const provenanceSource = options?.source?.trim() || source
-	const parsed = parseFrontmatterBlock(await readFile(item.filePath, "utf8"))
-	const sources = new Set(
-		Array.isArray(parsed.data.sources) ? parsed.data.sources : [],
-	)
-	sources.add(provenanceSource)
-	const nextBody =
-		options?.mode === "append"
-			? `${parsed.body.trim()}\n\n${text.trim()}`.trim()
-			: text.trim()
-
-	await writeFile(
-		item.filePath,
-		`${frontmatter({
-			id: typeof parsed.data.id === "string" ? parsed.data.id : item.id,
-			scope:
-				typeof parsed.data.scope === "string" ? parsed.data.scope : item.scope,
-			project:
-				typeof parsed.data.project === "string"
-					? parsed.data.project
-					: getProjectSlug(ctx.cwd),
-			agent:
-				typeof parsed.data.agent === "string" ? parsed.data.agent : agentId,
-			kind: typeof parsed.data.kind === "string" ? parsed.data.kind : item.kind,
-			confidence:
-				typeof parsed.data.confidence === "string"
-					? parsed.data.confidence
-					: "0.90",
+	return withAgentMutationLock(agentId, async () => {
+		const { paths, worktreeKey, source } = await resolveMutationPaths(
+			pi,
+			ctx,
+			agentId,
+		)
+		const item = await findMemoryItemInPaths(paths, selector)
+		if (!item) throw new Error(`Could not find memory item: ${selector}`)
+		const now = new Date().toISOString()
+		const provenanceSource = options?.source?.trim() || source
+		const parsed = parseFrontmatterBlock(await readFile(item.filePath, "utf8"))
+		const sources = new Set(
+			Array.isArray(parsed.data.sources) ? parsed.data.sources : [],
+		)
+		sources.add(provenanceSource)
+		const nextBody =
+			options?.mode === "append"
+				? `${parsed.body.trim()}\n\n${text.trim()}`.trim()
+				: text.trim()
+		await writeFile(
+			item.filePath,
+			`${frontmatter({
+				id: typeof parsed.data.id === "string" ? parsed.data.id : item.id,
+				scope:
+					typeof parsed.data.scope === "string"
+						? parsed.data.scope
+						: item.scope,
+				project:
+					typeof parsed.data.project === "string"
+						? parsed.data.project
+						: getProjectSlug(ctx.cwd),
+				agent:
+					typeof parsed.data.agent === "string" ? parsed.data.agent : agentId,
+				kind:
+					typeof parsed.data.kind === "string" ? parsed.data.kind : item.kind,
+				confidence:
+					typeof parsed.data.confidence === "string"
+						? parsed.data.confidence
+						: "0.90",
+				sources: [...sources],
+				created_at:
+					typeof parsed.data.created_at === "string"
+						? parsed.data.created_at
+						: now,
+				updated_at: now,
+			})}
+${nextBody}
+`,
+			"utf8",
+		)
+		await appendTimeline(paths, {
+			id: item.id,
+			timestamp: now,
+			action: "update",
+			agent: agentId,
+			file: item.filePath,
+			mode: options?.mode ?? "replace",
+			source: provenanceSource,
+		})
+		await commitWorktreeChanges(
+			pi,
+			paths.workTree,
+			`docs(memory): update ${item.id}`,
+			toWorktreeRelativePaths(paths, [item.filePath, paths.timelineFile]),
+		)
+		await fastForwardCanonicalBranch(pi, paths, worktreeKey)
+		await pushCanonicalBranchToBare(pi, paths)
+		return {
+			...item,
+			body: nextBody,
+			updatedAt: now,
 			sources: [...sources],
-			created_at:
-				typeof parsed.data.created_at === "string"
-					? parsed.data.created_at
-					: now,
-			updated_at: now,
-		})}\n\n${nextBody}\n`,
-		"utf8",
-	)
-	await appendTimeline(paths, {
-		id: item.id,
-		timestamp: now,
-		action: "update",
-		agent: agentId,
-		file: item.filePath,
-		mode: options?.mode ?? "replace",
-		source: provenanceSource,
+		}
 	})
-	await commitWorktreeChanges(
-		pi,
-		paths.workTree,
-		`docs(memory): update ${item.id}`,
-		toWorktreeRelativePaths(paths, [item.filePath, paths.timelineFile]),
-	)
-	await fastForwardCanonicalBranch(pi, paths, worktreeKey)
-	await pushCanonicalBranchToBare(pi, paths)
-
-	return {
-		...item,
-		body: nextBody,
-		updatedAt: now,
-		sources: [...sources],
-	}
 }
 
 export async function getMemoryHistoryFromPaths(
@@ -490,46 +625,47 @@ export async function deleteMemoryItem(
 	agentId: string,
 	selector: string,
 ): Promise<MemoryItem> {
-	const { paths, worktreeKey, source } = await resolveMutationPaths(
-		pi,
-		ctx,
-		agentId,
-	)
-	const item = await findMemoryItemInPaths(paths, selector)
-	if (!item) throw new Error(`Could not find memory item: ${selector}`)
-	await unlink(item.filePath)
-	const now = new Date().toISOString()
-	const provenanceSource = source
-	await appendTimeline(paths, {
-		id: item.id,
-		timestamp: now,
-		action: "delete",
-		agent: agentId,
-		file: item.filePath,
-		source: provenanceSource,
+	return withAgentMutationLock(agentId, async () => {
+		const { paths, worktreeKey, source } = await resolveMutationPaths(
+			pi,
+			ctx,
+			agentId,
+		)
+		const item = await findMemoryItemInPaths(paths, selector)
+		if (!item) throw new Error(`Could not find memory item: ${selector}`)
+		await unlink(item.filePath)
+		const now = new Date().toISOString()
+		const provenanceSource = source
+		await appendTimeline(paths, {
+			id: item.id,
+			timestamp: now,
+			action: "delete",
+			agent: agentId,
+			file: item.filePath,
+			source: provenanceSource,
+		})
+		await appendCandidates(paths, {
+			id: item.id,
+			timestamp: now,
+			action: "delete",
+			agent: agentId,
+			file: item.filePath,
+			source: provenanceSource,
+		})
+		await commitWorktreeChanges(
+			pi,
+			paths.workTree,
+			`chore(memory): delete ${item.id}`,
+			toWorktreeRelativePaths(paths, [
+				item.filePath,
+				paths.timelineFile,
+				paths.candidatesFile,
+			]),
+		)
+		await fastForwardCanonicalBranch(pi, paths, worktreeKey)
+		await pushCanonicalBranchToBare(pi, paths)
+		return item
 	})
-	await appendCandidates(paths, {
-		id: item.id,
-		timestamp: now,
-		action: "delete",
-		agent: agentId,
-		file: item.filePath,
-		source: provenanceSource,
-	})
-	await commitWorktreeChanges(
-		pi,
-		paths.workTree,
-		`chore(memory): delete ${item.id}`,
-		toWorktreeRelativePaths(paths, [
-			item.filePath,
-			paths.timelineFile,
-			paths.candidatesFile,
-		]),
-	)
-	await fastForwardCanonicalBranch(pi, paths, worktreeKey)
-	await pushCanonicalBranchToBare(pi, paths)
-
-	return item
 }
 
 export function renderMemoryItem(item: MemoryItem): string {
@@ -567,7 +703,11 @@ export async function renderMemoryOverview(
 ): Promise<string> {
 	const { paths } = await ensureAgentLayout(pi, cwd, agentId)
 	const recentFiles = await getRecentFiles(paths.workTree, 8)
-	const rules = await collectMarkdownFiles(paths.rulesDir)
+	const rules = (
+		await Promise.all(
+			getRuleRoots(paths).map((dir) => collectMarkdownFiles(dir)),
+		)
+	).flat()
 	const worktrees = await listMemoryWorktrees(pi, paths)
 	const syncStatus = await renderSyncStatus(pi, paths)
 	return [
@@ -575,6 +715,14 @@ export async function renderMemoryOverview(
 		`Memory root: ${paths.workTree}`,
 		`Canonical worktree: ${getCanonicalWorkTree(paths)}`,
 		`Canonical repo: ${paths.bareRepo}`,
+		"",
+		"Hierarchy:",
+		`- system/ (pinned): ${paths.systemDir}`,
+		`- projects/<slug>/: ${paths.projectDir}`,
+		`- sessions/: ${paths.sessionsDir}`,
+		`- inbox/: ${paths.inboxDir}`,
+		`- archive/: ${paths.archiveDir}`,
+		"",
 		`Project summary: ${paths.projectSummaryFile}`,
 		`Latest summary: ${paths.latestSummaryFile}`,
 		`Rules: ${rules.length}`,
@@ -595,7 +743,6 @@ export async function renderMemoryOverview(
 			: ["- No memory files yet"]),
 	].join("\n")
 }
-
 export async function readFileIfPresent(
 	filePath: string,
 ): Promise<string | null> {
@@ -603,21 +750,38 @@ export async function readFileIfPresent(
 	return readFile(filePath, "utf8")
 }
 
+export async function readFirstPresentFile(
+	filePaths: string[],
+): Promise<string | null> {
+	for (const filePath of uniquePaths(filePaths)) {
+		const content = await readFileIfPresent(filePath)
+		if (content !== null) return content
+	}
+	return null
+}
+
+export async function collectMarkdownFilesFromRoots(
+	roots: string[],
+): Promise<string[]> {
+	const files = (
+		await Promise.all(roots.map((root) => collectMarkdownFiles(root)))
+	).flat()
+	return [...new Set(files)].sort()
+}
 export async function grepMemoryInPaths(
 	pi: ExtensionAPI,
 	paths: MemoryPaths,
 	query: string,
 	limit: number = 30,
 ): Promise<string> {
-	const grepRoots = [
+	const grepRoots = uniquePaths([
 		paths.projectDir,
-		paths.profileDir,
-		paths.agentNotesDir,
-		paths.sessionMemoryDir,
+		paths.systemDir,
 		paths.rulesDir,
+		paths.sessionMemoryDir,
 		paths.summariesDir,
 		paths.inboxDir,
-	]
+	])
 	try {
 		const result = await pi.exec("rg", [
 			"--hidden",

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -58,8 +58,8 @@ export function getPaths(
 	const mainWorkTree = path.join(agentDir, "memory")
 	const workTree = workTreeOverride ?? mainWorkTree
 	const projectDir = path.join(workTree, "projects", getProjectSlug(cwd))
+	const systemDir = path.join(workTree, "system")
 	const rulesDir = path.join(workTree, "rules")
-
 	return {
 		root,
 		stateFile: path.join(root, "state.json"),
@@ -68,10 +68,11 @@ export function getPaths(
 		bareRepo: path.join(agentDir, "memory.git"),
 		workTree,
 		worktreesDir: path.join(agentDir, "worktrees"),
-		profileDir: path.join(workTree, "profile"),
+		systemDir,
+		projectsDir: path.join(workTree, "projects"),
 		projectDir,
-		projectFactsDir: path.join(projectDir, "facts"),
-		projectSummaryFile: path.join(projectDir, "SUMMARY.md"),
+		projectSystemDir: path.join(projectDir, "system"),
+		projectSummaryFile: path.join(projectDir, "README.md"),
 		projectDecisionsFile: path.join(projectDir, "decisions.md"),
 		timelineFile: path.join(projectDir, "timeline.jsonl"),
 		scratchpadFile: path.join(projectDir, "scratchpad.md"),
@@ -81,11 +82,11 @@ export function getPaths(
 		latestSummaryFile: path.join(workTree, "summaries", "latest.md"),
 		inboxDir: path.join(workTree, "inbox"),
 		candidatesFile: path.join(workTree, "inbox", "candidates.jsonl"),
+		archiveDir: path.join(workTree, "archive"),
 		rulesDir,
-		projectRulesDir: path.join(rulesDir, "project"),
+		projectRulesDir: path.join(projectDir, "rules"),
 		agentRulesDir: path.join(rulesDir, "agent"),
 		generatedRulesDir: path.join(rulesDir, "generated"),
-		agentNotesDir: path.join(workTree, "agent"),
 	}
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,11 +1,8 @@
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent"
-
 export type Scope = "project" | "agent" | "session"
-
 export type PiettaState = {
 	currentAgentId: string
 }
-
 export type MemoryPaths = {
 	root: string
 	stateFile: string
@@ -14,9 +11,10 @@ export type MemoryPaths = {
 	bareRepo: string
 	workTree: string
 	worktreesDir: string
-	profileDir: string
+	systemDir: string
+	projectsDir: string
 	projectDir: string
-	projectFactsDir: string
+	projectSystemDir: string
 	projectSummaryFile: string
 	projectDecisionsFile: string
 	timelineFile: string
@@ -27,26 +25,24 @@ export type MemoryPaths = {
 	latestSummaryFile: string
 	inboxDir: string
 	candidatesFile: string
+	archiveDir: string
 	rulesDir: string
 	projectRulesDir: string
 	agentRulesDir: string
 	generatedRulesDir: string
-	agentNotesDir: string
 }
-
 export type EnsureResult = {
 	paths: MemoryPaths
 	created: string[]
 }
-
 export type RememberInput = {
 	text: string
 	scope: Scope
 	kind: string
 	confidence: number
 	source?: string
+	path?: string
 }
-
 export type MemoryItem = {
 	id: string
 	filePath: string
@@ -57,7 +53,6 @@ export type MemoryItem = {
 	sources: string[]
 	body: string
 }
-
 export type GitResult = {
 	stdout: string
 	stderr: string
@@ -71,22 +66,25 @@ export const EXTENSION_NAME = "pietta"
 export const DEFAULT_AGENT_ID = "default"
 export const SCOPE_VALUES = ["project", "agent", "session"] as const
 export const WORKTREE_REGISTRATION_RETRIES = 5
-
 export type AgentsArgs = {
 	command: string
 	value?: string
 }
-
 export type MemoryArgs = {
 	command: string
 	selector?: string
 	text?: string
 }
 
+export type RememberArgs = {
+	scope: Scope
+	scopeExplicit: boolean
+	path?: string
+	text: string
+}
 export type MutationPathsResult = {
 	paths: MemoryPaths
 	worktreeKey: string
 	source: string
 }
-
 export type SessionWorktreeResolver = (ctx: ExtensionContext) => string

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -70,14 +70,17 @@ export function registerTools(
 		name: "pietta_write_memory",
 		label: "Pietta Write Memory",
 		description:
-			"Write durable memory entries into the Pietta agent memory repo",
+			"Write durable memory entries into the Pietta agent memory repo, preferring pinned system areas for agent memory and project system areas for high-priority project memory. Split distinct topics into multiple focused memories, and keep each memory to roughly a paragraph or two when possible",
 		promptSnippet:
-			"Store durable memory aggressively, especially explicit user preferences and recurring constraints",
+			"Store durable memory aggressively, especially explicit user preferences, recurring constraints, and stable workflow notes in pinned system memory or project system memory when appropriate. If you pass `path`, make it a memory-local subpath like `preferences/coding_preferences`, not a full repo path like `projects/<slug>/README.md`",
 		promptGuidelines: [
 			"Always write durable memory when the user explicitly states a preference, default, recurring workflow, or standing constraint.",
 			"Do not wait for the user to ask to remember it if the preference is stated clearly.",
 			"Use this only for durable facts, preferences, rules, decisions, and environment constraints.",
 			"Do not store speculative assumptions, temporary plans, secrets, or credentials.",
+			"For project-scoped memories, prefer project system memory for durable project rules and conventions, and ordinary project memory for normal facts.",
+			"If you provide `path`, it must be a slash-separated path relative to the chosen memory area, without `.md`, and not a full repo path.",
+			"Do not target scaffold files like `README.md` in `projects/<slug>/`, `system/`, or `rules/`; create or update real memory files instead.",
 		],
 		parameters: Type.Object({
 			text: Type.String({ description: "The durable memory text to store" }),
@@ -95,6 +98,12 @@ export function registerTools(
 			source: Type.Optional(
 				Type.String({ description: "Optional provenance source" }),
 			),
+			path: Type.Optional(
+				Type.String({
+					description:
+						"Optional slash-separated memory-local subpath like `preferences/coding_preferences`; do not pass full repo paths such as `projects/<slug>/README.md` or include `.md`",
+				}),
+			),
 			agentId: Type.Optional(
 				Type.String({ description: "Optional agent ID override" }),
 			),
@@ -108,6 +117,7 @@ export function registerTools(
 				kind: params.kind?.trim() || "fact",
 				confidence: params.confidence ?? 0.9,
 				source: params.source,
+				path: params.path,
 			})
 			return {
 				content: [{ type: "text", text: `Stored memory in ${filePath}` }],
@@ -121,13 +131,19 @@ export function registerTools(
 		label: "Pietta Update Memory",
 		description:
 			"Update an existing Pietta memory item and refresh its updated_at field",
-		promptSnippet: "Update an existing Pietta memory entry by id or path",
+		promptSnippet:
+			"Update an existing Pietta memory entry by its memory id. If you use a filename or path instead of an id, include the `.md` extension. Prefer ids returned by list/show/grep results, not guessed repo paths or scaffold README files",
 		promptGuidelines: [
 			"Use this when the user wants to revise or correct an existing durable memory item.",
+			"Prefer the exact memory id from Pietta output, such as `project/user_preferences`.",
+			"If you use a filename or full path selector instead of an id, include the `.md` extension.",
+			"Do not guess selectors from repo layout. Avoid paths like `projects/<slug>/README.md`, which are scaffold or summary files rather than normal memory items.",
+			"If you are not sure which item to update, grep or list first, then use the returned id.",
 		],
 		parameters: Type.Object({
 			selector: Type.String({
-				description: "Memory id, filename, or full path",
+				description:
+					"Memory id preferred; filename or full path only when you already know it points to a real memory item, and those path-based selectors should include the `.md` extension. Do not use scaffold paths like `projects/<slug>/README.md`",
 			}),
 			text: Type.String({ description: "New body text for the memory item" }),
 			mode: Type.Optional(
@@ -178,13 +194,19 @@ export function registerTools(
 		label: "Pietta Delete Memory",
 		description:
 			"Delete an existing Pietta memory item and log the deletion in jsonl timelines",
-		promptSnippet: "Delete an existing Pietta memory entry by id or path",
+		promptSnippet:
+			"Delete an existing Pietta memory entry by its memory id. If you use a filename or path instead of an id, include the `.md` extension. Prefer ids from Pietta results, not guessed repo paths or scaffold README files",
 		promptGuidelines: [
 			"Use this when the user explicitly wants a memory item forgotten or removed.",
+			"Prefer the exact memory id from Pietta output.",
+			"If you use a filename or full path selector instead of an id, include the `.md` extension.",
+			"Do not guess selectors from repo layout or use scaffold files like `projects/<slug>/README.md`.",
+			"If you are unsure which item to delete, grep or list first, then delete by id.",
 		],
 		parameters: Type.Object({
 			selector: Type.String({
-				description: "Memory id, filename, or full path",
+				description:
+					"Memory id preferred; filename or full path only when you already know it points to a real memory item, and those path-based selectors should include the `.md` extension. Do not use scaffold paths like `projects/<slug>/README.md`",
 			}),
 			agentId: Type.Optional(
 				Type.String({ description: "Optional agent ID override" }),


### PR DESCRIPTION
Fixes https://github.com/bitbloxhub/pietta/issues/11

- remove Pietta-prescribed workflow/preferences/agent subfolder taxonomy
- keep only top-level system, projects, sessions, and rules structure
- add projects/<slug>/system for project-pinned memory
- default project memories to projects/<slug>/ unless higher-priority project memory belongs in projects/<slug>/system
- route /remember through a real user-message flow
- make remember/init prompting more Letta-style
- encourage splitting memories into small focused notes instead of large catch-all files
- clean up leftover unused code and stale path aliases